### PR TITLE
Jenkinsfile 중괄호 누락 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
-pipeline
+pipeline {
     agent any
+
     stages {
         stage('build') {
             steps {
@@ -35,3 +36,4 @@ pipeline
             echo 'Build failed.'
         }
     }
+}


### PR DESCRIPTION
### ✅ 이슈
- close #3 

### ✏️  내용
- Jenkinsfile의 pipeline 문법에서 '{', '}' 중괄호가 누락된 버그 수정
```
pipeline {
    
}
```