### PR TITLE
Jenkinsfile 무한루프 해결

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,14 @@
 pipeline {
     agent any
 
+    options {
+        timeout(time: 5, unit: 'MINUTES')   // timeout 5분 설정
+    }
+
+    environment {
+        GRADLE_USER_HOME = "${WORKSPACE}/.gradle"   // Gradle 캐시 설정
+    }
+
     stages {
         stage('build') {
             steps {


### PR DESCRIPTION
### ✅  이슈
- close #5 

### ✏️  작업내용
- Jenkins 파이프라인 실행 시 무한루프에 빠지는 상황 해결을 위해 Gradle 캐시, Timeout 설정 추가