### PR TITLE
jar 파일 여러 개 생성되는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,3 +34,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
### ✅ 이슈
- close #9 

### ✏️ 작업내용
- Gradle Build 시 jar 파일이 두 개 생성되는 것을 발견
<img width="328" alt="스크린샷 2025-01-21 오후 6 09 47" src="https://github.com/user-attachments/assets/4ceb9e1a-78b6-4397-b3a5-893ca3911d86" />

- Dockerfile을 통해 jar 파일로 도커 이미지를 빌드하는 과정에서 jar 파일이 두 개가 되면서 에러 발생
- build.gradle 파일에 jar 설정 추가
```
jar {
    enabled = false
}
```
