### PR TITLE
Jenkins 파이프라인 배포환경 환경변수 export 과정 삭제

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,19 +78,13 @@ pipeline {
                             string(credentialsId: 'ec2-user', variable: 'EC2_USER'),
                             string(credentialsId: 'ec2-host', variable: 'EC2_HOST')]) {
                         sshagent(['ssh-credentials']) {
-                            def dockerContainerName = "test-server-container"
+                            def DOCKER_CONTAINER_NAME = "test-server-container"
 
                             sh"""
                             # SSH EC2 연결
                             ssh -o StrictHostKeyChecking=no ${EC2_USER}@${EC2_HOST} << EOF
                                 set -e
                                 echo "Connected to EC2"
-                                
-                                # 배포환경 환경변수 정의
-                                export DOCKERHUB_ACCESS_TOKEN="$DOCKER_PASSWORD"
-                                export DOCKERHUB_USERNAME="$DOCKER_USERNAME"
-                                export DOCKER_IMAGE="$DOCKER_IMAGE"
-                                export DOCKER_CONTAINER_NAME="$dockerContainerName"
                                 
                                 # 도커 로그인
                                 echo "\$DOCKERHUB_ACCESS_TOKEN | docker login -u "\$DOCKERHUB_USERNAME --password-stdin


### PR DESCRIPTION
### ✏️ 작업내용
- Jenkins 파이프라인에서 설정한 환경변수를 배포환경에 export 하는 과정 제거
- Jenkins 서버와 SpringBoot Application 서버가 각 독립된 환경이라 SpringBoot Application 서버 EC2에 접속했을 때 해당 환경의 환경 변수로 등록되어야 쉘 스크립트 bash에서 해당 변수에 접근할 수 있는 줄 알았지만 Jenkins 환경 변수 값을 직접 삽입해 작업을 수행할 수 있음