### PR TITLE
Jenkins 멀티브랜치 파이프라인 적용

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
                         echo \$DOCKERHUB_ACCESS_TOKEN | docker login -u \$DOCKERHUB_USERNAME --password-stdin
 
                         # 도커 이미지 빌드
-                        docker image -t $dockerImage .
+                        docker build -t $dockerImage .
 
                         # 도커 이미지 push
                         docker push $dockerImage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
 
     environment {
         GRADLE_USER_HOME = "${WORKSPACE}/.gradle"   // Gradle 캐시 설정
+        DOCKER_IMAGE = 'jenkins-test:latest'
     }
 
     stages {
@@ -14,60 +15,76 @@ pipeline {
         stage('Checkout Source') {
             steps {
                 script {
-                    echo "Checking out branch: ${env.GIT_BRANCH}"
+                    echo "Checking out branch: ${env.BRANCH_NAME}"
 
-                    checkout([
-                            $class: 'GitSCM',
-                            branches: [[name: "${env.GIT_BRANCH}"]]
-                    ])
+                    // 멀티브랜치 파이프라인 -> 현재 빌드 중인 브랜치를 자동으로 감지하고 체크아웃
+                    checkout scm
                 }
             }
         }
 
-        // CI : Gradle 빌드 및 테스트
-        stage('CI - Build and Test') {
+        // CI : Gradle 빌드 및 테스트, 도커 이미지 빌드 및 push
+        stage('CI - Build and Test, Docker Image Build and Push') {
+            // 모든 브랜치 PR 이벤트 시 실행
+            when {
+                expression {
+                    def isPR = env.CHANGE_ID != null    // PR 이벤트 여부 (true: PR, false: 다른 이벤트)
+                    return isPR
+                }
+            }
             steps {
                 script {
-                    echo 'Running CI pipeline...'
+                    echo "Running CI pipeline... for branch: ${env.BRANCH_NAME}"
 
                     // Gradle 테스트 실행 및 빌드 성공 여부 확인
                     sh './gradlew clean build --no-daemon'
+
+                    // 도커 이미지 빌드 및 push
+                    withCredentials([
+                            usernamePassword(
+                                    credentialsId: 'docker-credentials',
+                                    usernameVariable: 'DOCKERHUB_USERNAME',
+                                    passwordVariable: 'DOCKERHUB_ACCESS_TOKEN'
+                            )
+                    ]) {
+                        def dockerImage = "${DOCKERHUB_USERNAME}/${env.DOCKER_IMAGE}"
+
+                        sh """
+                        # 도커 로그인
+                        echo \$DOCKERHUB_ACCESS_TOKEN | docker login -u \$DOCKERHUB_USERNAME --password-stdin
+
+                        # 도커 이미지 빌드
+                        docker image -t $dockerImage .
+
+                        # 도커 이미지 push
+                        docker push $dockerImage
+                        """
+                    }
                 }
             }
         }
 
-        // CD : 도커 이미지 빌드 및 배포
-        stage('CD - Docker Image Build and Deploy') {
-            // develop, main 브랜치에서만 작업 수행
+        // CD : SSH EC2 연결 및 배포
+        stage('CD - Deploy') {
+            // develop, main 브랜치의 push 이벤트 시 작업 수행
             when {
                 expression {
-                    ['develop', 'main'].contains(env.GIT_BRANCH?.replaceFirst(/^origin\//, ''))
+                    def branch = env.BRANCH_NAME
+                    return ['develop', 'main'].contains(branch) && env.CHANGE_ID == null    // develop, main 브랜치 push 이벤트
                 }
             }
             steps {
                 script {
-                    echo 'Running CD pipeline...'
+                    echo "Running CD pipeline... for branch: ${env.BRANCH_NAME}"
 
                     withCredentials([
                             usernamePassword(credentialsId: 'docker-credentials', usernameVariable: 'DOCKERHUB_USERNAME', passwordVariable: 'DOCKERHUB_ACCESS_TOKEN'),
                             string(credentialsId: 'ec2-user', variable: 'EC2_USER'),
                             string(credentialsId: 'ec2-host', variable: 'EC2_HOST')]) {
                         // 도커 이미지
-                        def DOCKER_IMAGE = '${DOCKERHUB_USERNAME}/jenkins-test:latest'
+                        def dockerImage = "${DOCKERHUB_USERNAME}/${env.DOCKER_IMAGE}"
                         // 도커 컨테이너
-                        def DOCKER_CONTAINER_NAME = "test-server-container"
-
-                        // 도커 이미지 build & push
-                        sh """
-                        # 도커 로그인
-                        echo \$DOCKERHUB_ACCESS_TOKEN | docker login -u \$DOCKERHUB_USERNAME --password-stdin
-                        
-                        # 도커 이미지 build
-                        docker build -t $DOCKER_IMAGE .
-
-                        # 도커 이미지 push
-                        docker push $DOCKER_IMAGE
-                        """
+                        def dockerContainerName = "test-server-container"
 
                         // SSH EC2 연결
                         sshagent(['ssh-credentials']) {
@@ -80,14 +97,14 @@ pipeline {
                                 echo \$DOCKERHUB_ACCESS_TOKEN | docker login -u \$DOCKERHUB_USERNAME --password-stdin
                                 
                                 # 도커 이미지 pull
-                                docker pull $DOCKER_IMAGE
+                                docker pull $dockerImage
 
                                 # 기존 도커 컨테이너 중지 및 삭제
-                                docker stop $DOCKER_CONTAINER_NAME 2>/dev/null || true
-                                docker rm $DOCKER_CONTAINER_NAME 2>/dev/null || true
+                                docker stop $dockerContainerName 2>/dev/null || true
+                                docker rm $dockerContainerName 2>/dev/null || true
 
                                 # 도커 컨테이너 실행
-                                docker run -d --name $DOCKER_CONTAINER_NAME -p 8080:8080 $DOCKER_IMAGE
+                                docker run -d --name $dockerContainerName -p 8080:8080 $dockerImage
 
                                 # 사용하지 않는 도커 이미지 모두 삭제
                                 docker image prune -a -f


### PR DESCRIPTION
### ✅ 이슈
- close #17 

### ✏️ 작업내용
- 젠킨스 단일 파이프라인 -> 멀티브랜치 파이프라인 적용
- 모든 브랜치의 PR 이벤트 트리거 시 CI 작업을 수행하도록 변경
- 도커 이미지 빌드 및 push 작업을 CI 작업에서 수행하도록 변경, PR 이벤트 발생 시 병합 전과 병합 후 상태를 검증하고 성공할 경우 병합 후의 상태를 도커 이미지로 빌드하고 push 작업을 수행하도록 변경
- develop, main 브랜치의 push 이벤트 트리거 시에만 CD 작업 수행하도록 변경 -> develop, main 브랜치로 push 혹은 merge 하기전 PR 이벤트에서 미리 검증을 진행하기 때문에 CI 작업을 수행하지 않고 배포 작업만 수행하도록 변경 (리소스 낭비 방지)