### PR TITLE
젠킨스 파이프라인 결과 아카이빙 코드 주석처리

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
     post {
         always {
             // 빌드 후 로그 정리 및 결과 아카이빙
-            archiveArtifacts artifacts: 'build/libs/*.jar', fingerprint: true
+            // archiveArtifacts artifacts: 'build/libs/*.jar', fingerprint: true
 
             // 슬랙 알림 전송
             echo 'Send slack alert.'


### PR DESCRIPTION
### ✅ 이슈
- close #19 

### ✏️ 작업내용
- post > always 작업에서 결과를 아카이빙하는 코드 주석처리
- develop 브랜치로 병합과정에서 CD 작업만 수행하기 때문에 build된 jar 파일이 생성되지 않은 상태에서 post > always 작업에서 /build/libs/*.jar 결과를 아카이빙하는 작업에서 jar 파일이 존재하지 않아 젠킨스 파이프라인이 실패하는 오류 해결