### PR TITLE
배포환경 docker compose 적용 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  spring-server:
+    image: shyeonpk/jenkins-test
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+    env_file:
+      - .env
+    environment:
+      - TZ=Asia/Seoul
+    networks:
+      - app-network
+
+  redis:
+    image: redis:latest
+    container_name: redis-container
+    ports:
+      - "6379:6379"
+    networks:
+      - app-network
+
+networks:
+  app-network:

--- a/src/main/java/com/sh/cicd/infrastructure/redis/RedisConfig.java
+++ b/src/main/java/com/sh/cicd/infrastructure/redis/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.sh.cicd.infrastructure.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}


### PR DESCRIPTION
### ✅ 이슈
- close #21 

### ✏️ 작업내용
- 기존 배포환경에서 도커를 사용해 배포하던 방법에서 도커 컴포즈를 이용한 방법으로 변경
- 배포환경에서 spring boot 서버와 redis 서버를 하나의 컨테이너로 관리하기 위해 도커 컴포즈 적용
- docker-compose.yml 파일을 통해 배포환경에서 docker compose로 컨테이너를 관리하도록 적용
- redis 관련 의존성 및 설정 추가